### PR TITLE
MLE-28076: stabilize UBI libnsl dependency against glibc updates

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -27,6 +27,8 @@ If you are using Copilot/AI to modify this repo, follow the **How Copilot Should
 - **Dockerfile templates (`dockerFiles/*`)**
   - Keep the multi-stage + flattened final stage pattern (`COPY --from=builder / /`).
   - Keep ownership/permissions correct for rootless (`marklogic_user:users`, UID 1000).
+  - When a Dockerfile installs RPMs from trusted external repos such as AlmaLinux or Rocky Linux, avoid broad `microdnf update` steps that can move `glibc` ahead of a pinned compatibility package.
+  - If a compatibility package must stay pinned, prefer targeted package upgrades over blanket updates, and validate downstream steps that rely on current repo state such as `microdnf reinstall tzdata`.
   - If you add/remove files, update `test/structure-test.yaml` accordingly.
 - **Env vars / secrets**
   - Keep naming consistent across `README.md`, `docker-compose/*.yaml`, Dockerfiles, and tests.
@@ -40,6 +42,7 @@ If you are using Copilot/AI to modify this repo, follow the **How Copilot Should
 - Use `make lint` to run ShellCheck + Hadolint.
 - Use `make test` for `structure-test` + Robot tests.
 - This repo builds images for `linux/amd64` by default.
+- When changing dependency images, validate both layers: build the `marklogic-deps-*` image and then verify MarkLogic RPM installation or the corresponding `marklogic-server-*` build path.
 - macOS note: `make structure-test` uses GNU-style `sed -i` (GNU sed syntax); on macOS you may need GNU sed (`gsed`) or run the build/test in a Linux container/VM.
 
 ## Project Overview
@@ -219,6 +222,8 @@ The pipeline supports:
 - Image publishing to Artifactory and Azure Container Registry
 
 **Pipeline stages:** Checkout → Lint → Build → Structure Test → Docker Tests → Scan → Publish
+
+**PR workflow note:** Open the pull request against `upstream/develop`, not a fork branch, because Jenkins validates PRs from the upstream repository as `KubeNinjas/docker/Docker_CI/PR-<number>` jobs.
 
 ## Contributing Notes
 

--- a/dockerFiles/marklogic-deps-ubi9:base
+++ b/dockerFiles/marklogic-deps-ubi9:base
@@ -8,11 +8,11 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1771346502
 LABEL "com.marklogic.maintainer"="docker@marklogic.com"
 
 ###############################################################
-# install libnsl rpm package
+# install libnsl rpm package from trusted repositories
 ###############################################################
 
-RUN microdnf -y update \
-    && rpm -i https://repo.almalinux.org/almalinux/9/BaseOS/x86_64/os/Packages/libnsl-2.34-231.el9_7.10.x86_64.rpm
+RUN rpm -i https://repo.almalinux.org/almalinux/9/BaseOS/x86_64/os/Packages/libnsl-2.34-231.el9_7.10.x86_64.rpm \
+    && microdnf clean all
 
 ###############################################################
 # install networking, base deps and tzdata for timezone

--- a/dockerFiles/marklogic-deps-ubi9:base
+++ b/dockerFiles/marklogic-deps-ubi9:base
@@ -20,6 +20,7 @@ RUN rpm -i https://repo.almalinux.org/almalinux/9/BaseOS/x86_64/os/Packages/libn
 # hadolint ignore=DL3006
 RUN echo "NETWORKING=yes" > /etc/sysconfig/network \
     && microdnf -y install --setopt install_weak_deps=0 gdb nss libtool-ltdl cpio tzdata util-linux hostname \
+    && microdnf -y upgrade tzdata \
     && microdnf clean all
 
 

--- a/dockerFiles/marklogic-deps-ubi:base
+++ b/dockerFiles/marklogic-deps-ubi:base
@@ -11,18 +11,18 @@ LABEL "com.marklogic.maintainer"="docker@marklogic.com"
 ARG ML_VERSION
 
 ###############################################################
-# install libnsl rpm package
+# install libnsl rpm package from trusted repositories
 ###############################################################
 
-RUN microdnf -y update \
-    && rpm -i https://repo.almalinux.org/almalinux/8/BaseOS/x86_64/os/Packages/libnsl-2.28-251.el8_10.27.x86_64.rpm
+RUN rpm -i https://repo.almalinux.org/almalinux/8/BaseOS/x86_64/os/Packages/libnsl-2.28-251.el8_10.27.x86_64.rpm \
+    && microdnf clean all
 
 ###############################################################
 # install networking, base deps and tzdata for timezone
 ###############################################################
 # hadolint ignore=DL3006
 RUN echo "NETWORKING=yes" > /etc/sysconfig/network \
-    && microdnf -y install --setopt install_weak_deps=0 gdb redhat-lsb-core initscripts tzdata glibc libstdc++ hostname \
+    && microdnf -y install --setopt install_weak_deps=0 gdb redhat-lsb-core initscripts tzdata libstdc++ hostname \
     && microdnf clean all
 
 ###############################################################

--- a/dockerFiles/marklogic-deps-ubi:base
+++ b/dockerFiles/marklogic-deps-ubi:base
@@ -23,6 +23,7 @@ RUN rpm -i https://repo.almalinux.org/almalinux/8/BaseOS/x86_64/os/Packages/libn
 # hadolint ignore=DL3006
 RUN echo "NETWORKING=yes" > /etc/sysconfig/network \
     && microdnf -y install --setopt install_weak_deps=0 gdb redhat-lsb-core initscripts tzdata libstdc++ hostname \
+    && microdnf -y upgrade tzdata \
     && microdnf clean all
 
 ###############################################################


### PR DESCRIPTION
## Summary\n- keep libnsl sourced from trusted AlmaLinux repositories\n- prevent the UBI dependency stage from upgrading glibc in the libnsl installation step\n- remove explicit glibc install from UBI8 deps package list to avoid unintentional upgrades\n\n## Why\nDocker UBI builds fail when glibc updates ahead of the pinned libnsl package available in trusted mirrors. This keeps the dependency pair stable until newer libnsl builds are published.\n\n## Validation\n- built dependency images locally:\n  - dockerFiles/marklogic-deps-ubi:base\n  - dockerFiles/marklogic-deps-ubi9:base\n- installed MarkLogic RPMs successfully in both images:\n  - MarkLogic-11.3.20260225-rhel.x86_64.rpm\n  - MarkLogic-11.3.20260225-rhel9.x86_64.rpm\n- ran make lint successfully\n